### PR TITLE
Fix (possibly) undefined bit shifts

### DIFF
--- a/src/cwpack_internals.h
+++ b/src/cwpack_internals.h
@@ -337,7 +337,7 @@
 
 #define getDDItemFix(len)                                                   \
     cw_unpack_assert_space(len+1);                                          \
-    unpack_context->item.type = *(int8_t*)p++;                              \
+    unpack_context->item.type = (cwpack_item_types)*(int8_t*)p++;           \
     if (unpack_context->item.type == CWP_ITEM_TIMESTAMP)                     \
     {                                                                       \
         if (len == 4)                                                       \


### PR DESCRIPTION
Bit shifts wider than the bit size of the shifted expression result in
undefined behavior. Depending on the sizes of the struct timespec
members, shifts of 34 bits may be too wide.
Also, MessagePack doesn't seem to support timestamps before 1970, i.e.
with negative struct timespec members.

The other changes mostly fix warnings about unreachable statements, or
assignments between enums and plain ints.