### PR TITLE
Fix storage of multi-byte integers on big endian machines.

### DIFF
--- a/src/cwpack_internals.h
+++ b/src/cwpack_internals.h
@@ -50,10 +50,10 @@
 
 #ifdef COMPILE_FOR_BIG_ENDIAN
 
-#define cw_store16(x)  *(uint16_t*)p = *(uint16_t*)&x;
-#define cw_store32(x)  *(uint32_t*)p = *(uint32_t*)&x;
+#define cw_store16(x)  *(uint16_t*)p = (uint16_t)x;
+#define cw_store32(x)  *(uint32_t*)p = (uint32_t)x;
 #ifndef FORCE_ALIGNMENT_64BIT
-#define cw_store64(x)  *(uint64_t*)p = *(uint64_t*)&x;
+#define cw_store64(x)  *(uint64_t*)p = (uint64_t)x;
 #else
 #define cw_store64(x)  memcpy(p,&x,8);
 #endif


### PR DESCRIPTION
I am cross-building CWPack for a big endian architecture and found issues when storing integers.
The macros cw_store[16|32|64] are fed with a 64-bit integer and cast the address of the value to be stored to the respective pointer type. For the two shorter types that means that the cast pointer points to the upper bytes of teh 64-bit value which are zero. As a result the function stores the value 0 instead of the real value.
Instead, the macros must cast the value itself. I have fixed and tested that.
For 64-bit integers that should not be an issue. However, for code consistency I have patched that as well.