### PR TITLE
trim trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CWPack
 
-CWPack is a lightweight and yet complete implementation of the 
-[MessagePack](http://msgpack.org) serialization format 
+CWPack is a lightweight and yet complete implementation of the
+[MessagePack](http://msgpack.org) serialization format
 [version 5](https://github.com/msgpack/msgpack/blob/master/spec.md).
 It also supports the Timestamp extension type.
 
@@ -14,7 +14,7 @@ Together with [MPack](https://github.com/ludocode/mpack), CWPack is the fastest 
 
 CWPack does no memory allocations and no file handling in its basic setup. All that is done outside of CWPack. Example extensions are included.
 
-CWPack is working against memory buffers. User defined handlers are called when buffers are filled up (packing) or needs refill (unpack). 
+CWPack is working against memory buffers. User defined handlers are called when buffers are filled up (packing) or needs refill (unpack).
 
 Containers (arrays, maps) are read/written in parts, first the item containing the size and then the contained items one by one. Exception to this is the `cw_skip_items` function which skip whole containers.
 
@@ -49,7 +49,7 @@ void example (void)
     if (cw_unpack_next_str_lengh(&uc) != 6) ERROR;
     if (strncmp("schema", uc.item.as.str.start, 6)) ERROR;
     if (cw_unpack_next_signed32(&uc) != 0) ERROR;
-    
+
     if (uc.return_code != CWP_RC_OK)  ERROR;
     cw_unpack_next(&uc);
     if (uc.return_code != CWP_RC_END_OF_INPUT)  ERROR;

--- a/example/README.md
+++ b/example/README.md
@@ -4,7 +4,7 @@ The example contains a program that takes a json file and converts it to a messa
 
 In the script runExample.sh the 2 json files are also diffed.
 
-The files `item.*` contains a memory tree representation of json data and the conversion routines:  
+The files `item.*` contains a memory tree representation of json data and the conversion routines:
 
 - Item Tree To Json File
 - Item Tree To MessagePack File

--- a/example/item.c
+++ b/example/item.c
@@ -1,18 +1,18 @@
 /*      CWPack/example - item.c   */
 /*
  The MIT License (MIT)
- 
+
  Copyright (c) 2017 Claes Wihlborg
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy of this
  software and associated documentation files (the "Software"), to deal in the Software
  without restriction, including without limitation the rights to use, copy, modify,
  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
  persons to whom the Software is furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all copies or
  substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
  BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -44,7 +44,7 @@ void freeItem3 (item_root* root)
             {
                 freeItem3(ic->items[i]);
             }
-            
+
         default:
             free(root);
     }
@@ -62,7 +62,7 @@ static void item32jsonFile (FILE* file, item_root* item)
     char c;
     unsigned u, ti;
     static unsigned tabs = 0;
-    
+
 #define NEW_LINE {fprintf (file, "\n"); for (ti=0; ti<tabs; ti++) fprintf (file, "\t");}
 
     switch (item->item_type)
@@ -83,7 +83,7 @@ static void item32jsonFile (FILE* file, item_root* item)
             NEW_LINE
             fprintf (file, "}");
             break;
-            
+
         case ITEM_ARRAY:
             jc = (item_container*)item;
             fprintf (file, "[");
@@ -98,23 +98,23 @@ static void item32jsonFile (FILE* file, item_root* item)
             NEW_LINE
             fprintf(file, "]");
             break;
-            
+
         case ITEM_NIL:
             fprintf (file, "null");
             break;
-            
+
         case ITEM_TRUE:
             fprintf (file, "true");
             break;
-            
+
         case ITEM_FALSE:
             fprintf (file, "false");
             break;
-            
+
         case ITEM_INTEGER:
             fprintf (file, "%lld", ((item_integer*)item)->value);
             break;
-            
+
         case ITEM_REAL:
             sprintf (tmp, "%-25.15g", ((item_real*)item)->value);
             for (i=0;i<30;i++)
@@ -129,7 +129,7 @@ static void item32jsonFile (FILE* file, item_root* item)
             }
             fprintf (file, "%s", tmp);
             break;
-            
+
         case ITEM_STRING:
             fprintf (file, "\"");
             cp = ((item_string*)item)->string;
@@ -161,7 +161,7 @@ static void item32jsonFile (FILE* file, item_root* item)
                         case 0x0a: fprintf (file, "\\n");   break; /* LF */
                         case 0x0c: fprintf (file, "\\f");   break; /* FF */
                         case 0x0d: fprintf (file, "\\r");   break; /* CR */
-                            
+
                         default:
                             fprintf (file, "%c", c);
                             break;
@@ -169,7 +169,7 @@ static void item32jsonFile (FILE* file, item_root* item)
             }
             fprintf (file, "\"");
             break;
-            
+
         default:    break;
     }
 }
@@ -299,7 +299,7 @@ static item_root* jsonString2item3 (const char** ptr)
 {
     scanSpace;
     item_root* result = NULL;
-    
+
     char c = *(*ptr)++;
     switch (c) {
         case '{':
@@ -309,7 +309,7 @@ static item_root* jsonString2item3 (const char** ptr)
             else
                 result = (item_root*)pullMapPair (ptr, 0);
             break;
-            
+
         case '[':
             scanSpace;
             if (**ptr == ']')
@@ -317,12 +317,12 @@ static item_root* jsonString2item3 (const char** ptr)
             else
                 result = (item_root*)pullArray (ptr, 0);
             break;
-            
+
         case '"':   result = (item_root*)pullString (ptr, 0);break;
         case 'n':   result = allocate_item(item_root,ITEM_NIL,0); *ptr+=3;break;
         case 't':   result = allocate_item(item_root,ITEM_TRUE,0); *ptr+=3;break;
         case 'f':   result = allocate_item(item_root,ITEM_FALSE,0); *ptr+=4;break;
-            
+
         case '-':
         case '0': case '1': case '2': case '3': case '4': case '5': case '6': case '7': case '8': case '9':
         {
@@ -355,11 +355,11 @@ static item_root* jsonString2item3 (const char** ptr)
             }
         }
             break;
-            
+
         default:
             break;
     }
-    
+
     return result;
 }
 
@@ -369,7 +369,7 @@ item_root* jsonFile2item3 (FILE* file)
     fseek (file, 0, SEEK_END);
     long length = ftell(file);
     char* buffer = malloc (length+1);
-    
+
     fseek (file, 0l, SEEK_SET);
     fread (buffer, 1, length, file);
     buffer[length] = 0;
@@ -387,7 +387,7 @@ static void item32packContext(cw_pack_context* pc, item_root* item)
     int    i;
     item_container* ic;
     char* cp;
-    
+
     switch (item->item_type)
     {
         case ITEM_MAP:
@@ -396,39 +396,39 @@ static void item32packContext(cw_pack_context* pc, item_root* item)
             for( i=0; i< ic->count; i++)
                 item32packContext (pc, ic->items[i]);
             break;
-            
+
         case ITEM_ARRAY:
             ic = (item_container*)item;
             cw_pack_array_size(pc, ic->count);
             for( i=0; i< ic->count; i++)
                 item32packContext (pc, ic->items[i]);
             break;
-                        
+
         case ITEM_NIL:
             cw_pack_nil (pc);
             break;
-            
+
         case ITEM_TRUE:
             cw_pack_boolean(pc, true);
             break;
-            
+
         case ITEM_FALSE:
             cw_pack_boolean(pc, false);
             break;
-            
+
         case ITEM_INTEGER:
             cw_pack_signed(pc, ((item_integer*)item)->value);
             break;
-            
+
         case ITEM_REAL:
             cw_pack_double(pc, ((item_real*)item)->value);
             break;
-            
+
         case ITEM_STRING:
             cp = ((item_string*)item)->string;
             cw_pack_str(pc, cp, (unsigned)strlen(cp));
             break;
-            
+
         default:    break;
     }
 }
@@ -457,7 +457,7 @@ static item_root* packContext2item3 (cw_unpack_context* uc)
         case CWP_ITEM_NIL:
             result = allocate_item(item_root,ITEM_NIL,0);
             break;
-            
+
         case CWP_ITEM_BOOLEAN:
             if (uc->item.as.boolean)
             {
@@ -474,23 +474,23 @@ static item_root* packContext2item3 (cw_unpack_context* uc)
             result = (item_root*)allocate_item(item_integer,ITEM_INTEGER,0);
             ((item_integer*)result)->value = uc->item.as.i64;
             break;
-            
+
         case CWP_ITEM_FLOAT:
             result = (item_root*)allocate_item(item_real,ITEM_REAL,0);
             ((item_real*)result)->value = uc->item.as.real;
             break;
-            
+
         case CWP_ITEM_DOUBLE:
             result = (item_root*)allocate_item(item_real,ITEM_REAL,0);
             ((item_real*)result)->value = uc->item.as.long_real;
             break;
-            
+
         case CWP_ITEM_STR:
             result = (item_root*)allocate_item(item_string,ITEM_STRING,uc->item.as.str.length + 1);
             strncpy(((item_string*)result)->string, (const char*)uc->item.as.str.start, uc->item.as.str.length);
             ((item_string*)result)->string[uc->item.as.str.length] = 0;
             break;
-            
+
         case CWP_ITEM_MAP:
             dim = 2 * uc->item.as.map.size;
             ic = allocate_container(ITEM_MAP, dim);
@@ -500,7 +500,7 @@ static item_root* packContext2item3 (cw_unpack_context* uc)
             }
             result = (item_root*)ic;
             break;
-            
+
         case CWP_ITEM_ARRAY:
             dim = uc->item.as.array.size;
             ic = allocate_container(ITEM_ARRAY, dim);
@@ -510,7 +510,7 @@ static item_root* packContext2item3 (cw_unpack_context* uc)
             }
             result = (item_root*)ic;
             break;
-            
+
         default:
             result = NULL;
             break;

--- a/example/item.h
+++ b/example/item.h
@@ -1,18 +1,18 @@
 /*      CWPack/example - item.h   */
 /*
  The MIT License (MIT)
- 
+
  Copyright (c) 2017 Claes Wihlborg
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy of this
  software and associated documentation files (the "Software"), to deal in the Software
  without restriction, including without limitation the rights to use, copy, modify,
  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
  persons to whom the Software is furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all copies or
  substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
  BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -26,9 +26,9 @@
 
 
 
-    
+
     /**************  ITEMS  **********************/
-    
+
     typedef enum {
         ITEM_MAP,
         ITEM_ARRAY,
@@ -39,47 +39,47 @@
         ITEM_REAL,
         ITEM_STRING
     } item_types;
-    
+
     typedef struct {
         item_types     item_type;
     } item_root;
-    
+
     typedef struct {
         item_types     item_type;
         int            count;       /* in maps every association counts for 2 */
         item_root*     items[];
     } item_container;
-    
+
     typedef struct {
         item_types     item_type;
         long long      value;
     } item_integer;
-    
+
     typedef struct {
         item_types     item_type;
         double         value;
     } item_real;
-    
+
     typedef struct {
         item_types     item_type;
         char           string[];
     } item_string;
-    
-    
+
+
     void freeItem3 (item_root* root);
-    
-    
-    
+
+
+
     /**************  ITEMS TO/FROM FILE  **********************/
-    
+
     void item32JsonFile (FILE* file, item_root* item);
-    
+
     item_root* jsonFile2item3 (FILE* file);
-    
+
     void item32cwpackFile (FILE* file, item_root* item);
-    
+
     item_root* cwpackFile2item3 (FILE* file);
-    
-    
-    
+
+
+
 #endif /* item_h */

--- a/example/json2cwpack2json.c
+++ b/example/json2cwpack2json.c
@@ -1,18 +1,18 @@
 /*      CWPack/example - json2cwpack2json.c   */
 /*
  The MIT License (MIT)
- 
+
  Copyright (c) 2017 Claes Wihlborg
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy of this
  software and associated documentation files (the "Software"), to deal in the Software
  without restriction, including without limitation the rights to use, copy, modify,
  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
  persons to whom the Software is furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all copies or
  substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
  BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -37,22 +37,22 @@ int main(int argc, const char * argv[])
     }
     char filename[200];
     strcpy(filename, argv[1]);
-    
+
     FILE* jsonFileIn;
     FILE* jsonFileOut;
     FILE* cwpackFileIn;
     FILE* cwpackFileOut;
-    
+
     jsonFileIn = fopen (filename, "r");
     item_root* root = jsonFile2item3 (jsonFileIn);
     fclose(jsonFileIn);
-        
+
     strcat (filename, ".msgpack");
     cwpackFileOut = fopen (filename, "w");
     item32cwpackFile (cwpackFileOut, root);
     fclose(cwpackFileOut);
     freeItem3(root);
-    
+
     cwpackFileIn = fopen (filename, "r");
     root = cwpackFile2item3 (cwpackFileIn);
     fclose(cwpackFileIn);
@@ -62,6 +62,6 @@ int main(int argc, const char * argv[])
     item32JsonFile (jsonFileOut, root);
     fclose(jsonFileOut);
     freeItem3(root);
-    
+
     return 0;
 }

--- a/goodies/basic-contexts/basic_contexts.c
+++ b/goodies/basic-contexts/basic_contexts.c
@@ -1,18 +1,18 @@
 /*      CWPack/goodies - basic_contexts.c   */
 /*
  The MIT License (MIT)
- 
+
  Copyright (c) 2017 Claes Wihlborg
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy of this
  software and associated documentation files (the "Software"), to deal in the Software
  without restriction, including without limitation the rights to use, copy, modify,
  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
  persons to whom the Software is furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all copies or
  substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
  BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -44,7 +44,7 @@ static int handle_memory_pack_overflow(struct cw_pack_context* pc, unsigned long
     void *new_buffer = realloc (pc->start, buffer_length);
     if (!new_buffer)
         return CWP_RC_BUFFER_OVERFLOW;
-    
+
     pc->start = (uint8_t*)new_buffer;
     pc->current = pc->start + contains;
     pc->end = pc->start + buffer_length;
@@ -61,7 +61,7 @@ void init_dynamic_memory_pack_context (dynamic_memory_pack_context* dmpc, unsign
         dmpc->pc.return_code = CWP_RC_MALLOC_ERROR;
         return;
     }
-    
+
     cw_pack_context_init((cw_pack_context*)dmpc, buffer, buffer_length, &handle_memory_pack_overflow);
 }
 
@@ -106,11 +106,11 @@ static int handle_stream_pack_overflow(struct cw_pack_context* pc, unsigned long
     {
         while (buffer_length < more)
             buffer_length = 2 * buffer_length;
-        
+
         void *new_buffer = malloc (buffer_length);
         if (!new_buffer)
             return CWP_RC_BUFFER_OVERFLOW;
-        
+
         free(pc->start);
         pc->start = (uint8_t*)new_buffer;
         pc->end = pc->start + buffer_length;
@@ -130,7 +130,7 @@ void init_stream_pack_context (stream_pack_context* spc, unsigned long initial_b
         return;
     }
     spc->file = file;
-    
+
     cw_pack_context_init((cw_pack_context*)spc, buffer, buffer_length, &handle_stream_pack_overflow);
     cw_pack_set_flush_handler((cw_pack_context*)spc, &flush_stream_pack_context);
 }
@@ -158,16 +158,16 @@ static int handle_stream_unpack_underflow(struct cw_unpack_context* uc, unsigned
     {
         memmove (uc->start, uc->current, remains);
     }
-    
+
     if (suc->buffer_length < more)
     {
         while (suc->buffer_length < more)
             suc->buffer_length = 2 * suc->buffer_length;
-        
+
         void *new_buffer = realloc (uc->start, suc->buffer_length);
         if (!new_buffer)
             return CWP_RC_BUFFER_UNDERFLOW;
-        
+
         uc->start = (uint8_t*)new_buffer;
     }
     uc->current = uc->start;
@@ -180,7 +180,7 @@ static int handle_stream_unpack_underflow(struct cw_unpack_context* uc, unsigned
         suc->uc.err_no = ferror(suc->file);
         return CWP_RC_ERROR_IN_HANDLER;
     }
-    
+
     uc->end += l;
 
     return CWP_RC_OK;
@@ -198,7 +198,7 @@ void init_stream_unpack_context (stream_unpack_context* suc, unsigned long initi
     }
     suc->file = file;
     suc->buffer_length = buffer_length;
-    
+
     cw_unpack_context_init((cw_unpack_context*)suc, buffer, 0, &handle_stream_unpack_underflow);
 }
 
@@ -239,7 +239,7 @@ static int flush_file_pack_context(struct cw_pack_context* pc)
     }
     else
         fpc->pc.current = fpc->pc.start;
-    
+
     return CWP_RC_OK;
 }
 
@@ -249,7 +249,7 @@ static int handle_file_pack_overflow(struct cw_pack_context* pc, unsigned long m
     int rc = flush_file_pack_context(pc);
     if (rc != CWP_RC_OK)
         return rc;
-    
+
     uint8_t *bStart = fpc->barrier ? fpc->barrier : pc->current;
     unsigned long kept = (unsigned long)(pc->current - bStart);
     unsigned long buffer_length = (unsigned long)(pc->end - pc->start);
@@ -257,7 +257,7 @@ static int handle_file_pack_overflow(struct cw_pack_context* pc, unsigned long m
     {
         while (buffer_length < more + kept)
             buffer_length = 2 * buffer_length;
-        
+
         void *new_buffer = malloc (buffer_length);
         if (!new_buffer)
             return CWP_RC_BUFFER_OVERFLOW;
@@ -271,12 +271,12 @@ static int handle_file_pack_overflow(struct cw_pack_context* pc, unsigned long m
     {
         memcpy(pc->start, bStart, kept);
     }
-    
+
     if (fpc->barrier)
     {
         fpc->barrier = pc->start;
     }
-    
+
     pc->current = pc->start + kept;
     return CWP_RC_OK;
 }
@@ -294,7 +294,7 @@ void init_file_pack_context (file_pack_context* fpc, unsigned long initial_buffe
     fpc->fileDescriptor = fileDescriptor;
     fpc->fileDescriptor = fileDescriptor;
     fpc->barrier = NULL;
-    
+
     cw_pack_context_init((cw_pack_context*)fpc, buffer, buffer_length, &handle_file_pack_overflow);
     cw_pack_set_flush_handler((cw_pack_context*)fpc, &flush_file_pack_context);
 }
@@ -317,7 +317,7 @@ void terminate_file_pack_context(file_pack_context* fpc)
     fpc->barrier = NULL;
     cw_pack_context* pc = (cw_pack_context*)fpc;
     cw_pack_flush(pc);
-    
+
     if (pc->return_code != CWP_RC_MALLOC_ERROR)
         free(pc->start);
 }
@@ -337,16 +337,16 @@ static int handle_file_unpack_underflow(struct cw_unpack_context* uc, unsigned l
     {
         memcpy (uc->start, bStart, remains);
     }
-    
+
     if (auc->buffer_length < more + kept)
     {
         while (auc->buffer_length < more + kept)
             auc->buffer_length = 2 * auc->buffer_length;
-        
+
         void *new_buffer = realloc (uc->start, auc->buffer_length);
         if (!new_buffer)
             return CWP_RC_BUFFER_UNDERFLOW;
-        
+
         uc->start = (uint8_t*)new_buffer;
     }
     uc->current = uc->start + kept;
@@ -368,7 +368,7 @@ static int handle_file_unpack_underflow(struct cw_unpack_context* uc, unsigned l
         }
         uc->end += l;
     }
-    
+
     return CWP_RC_OK;
 }
 
@@ -385,7 +385,7 @@ void init_file_unpack_context (file_unpack_context* fuc, unsigned long initial_b
     fuc->fileDescriptor = fileDescriptor;
     fuc->barrier = NULL;
     fuc->buffer_length = buffer_length;
-    
+
     cw_unpack_context_init((cw_unpack_context*)fuc, buffer, 0, &handle_file_unpack_underflow);
 }
 

--- a/goodies/basic-contexts/basic_contexts.h
+++ b/goodies/basic-contexts/basic_contexts.h
@@ -1,18 +1,18 @@
 /*      CWPack/goodies - basic_contexts.h   */
 /*
  The MIT License (MIT)
- 
+
  Copyright (c) 2017 Claes Wihlborg
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy of this
  software and associated documentation files (the "Software"), to deal in the Software
  without restriction, including without limitation the rights to use, copy, modify,
  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
  persons to whom the Software is furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all copies or
  substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
  BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/goodies/dump/README.md
+++ b/goodies/dump/README.md
@@ -3,22 +3,22 @@
 
 Dump is a small program taking a msgpack file as input and produces a human readable file as output. The output is not json as msgpack is more feature-rich.
 
-Syntax:  
-cwpack_dump [-t 9] [-v] [-h] < msgpackFile > humanReadableFile  
--t 9 Tab size  
--v   Version  
--h   Help  
+Syntax:
+cwpack_dump [-t 9] [-v] [-h] < msgpackFile > humanReadableFile
+-t 9 Tab size
+-v   Version
+-h   Help
 
 Each topmost msgpack item in the file starts on a new line. Each line starts with a file offset (hex) of the first item on the line.
 If Tab size isn't given, structures are written on a single line.
 
-  
+
 `cwpack_dump < testdump.msgpack` prints:
 
 ```
      0  [10000000 3.14 "åäöÅÄÖ"]
     1c  {"binary": (62696e617279) "extension": (-5,68656c6c6f) "time": '2020-05-20 18:40:00'}
-    49  
+    49
 ```
 and `cwpack_dump -t 4 < testdump.msgpack` prints:
 
@@ -33,6 +33,6 @@ and `cwpack_dump -t 4 < testdump.msgpack` prints:
     2c      "extension": (-5,68656c6c6f)
     3e      "time": '2020-05-20 18:40:00'
     49  }
-    49  
+    49
 ```
 

--- a/goodies/dump/cwpack_dump.c
+++ b/goodies/dump/cwpack_dump.c
@@ -1,18 +1,18 @@
 /*      CWPack/goodies - cwpack_dump.c   */
 /*
  The MIT License (MIT)
- 
+
  Copyright (c) 2017 Claes Wihlborg
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy of this
  software and associated documentation files (the "Software"), to deal in the Software
  without restriction, including without limitation the rights to use, copy, modify,
  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
  persons to whom the Software is furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all copies or
  substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
  BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -47,7 +47,7 @@ static void dump_as_hex(const void* area, long length)
 
 static void dump_next_item( cw_unpack_context* context, int tabLevel)
 {
-    
+
     long long dim =99;
     int i,ti;
     double d;
@@ -63,32 +63,32 @@ static void dump_next_item( cw_unpack_context* context, int tabLevel)
         case CWP_ITEM_NIL:
             printf("null");
             break;
-            
+
         case CWP_ITEM_BOOLEAN:
             if (context->item.as.boolean)
                 printf("true");
             else
                 printf("false");
             break;
-            
+
         case CWP_ITEM_POSITIVE_INTEGER:
             printf("%llu", context->item.as.u64);
             break;
-            
+
         case CWP_ITEM_NEGATIVE_INTEGER:
             printf("%lld", context->item.as.i64);
             break;
-            
+
         case CWP_ITEM_FLOAT:
             context->item.as.long_real = (double)context->item.as.real;
-            
+
         case CWP_ITEM_DOUBLE:
             printf ("%g", context->item.as.long_real);
             break;
-            
+
         case CWP_ITEM_STR: {
             printf("\"");
-            
+
             for (i=0; i < (int)context->item.as.str.length; i++)
             {
                 unsigned char c = ((unsigned char*)(context->item.as.str.start))[i];
@@ -113,13 +113,13 @@ static void dump_next_item( cw_unpack_context* context, int tabLevel)
 
             printf("\"");
             break;}
-            
+
         case CWP_ITEM_BIN:
             printf("(");
             dump_as_hex (context->item.as.bin.start, context->item.as.bin.length);
             printf(")");
             break;
-            
+
         case CWP_ITEM_ARRAY:
             printf("[");
             dim = context->item.as.array.size;
@@ -133,7 +133,7 @@ static void dump_next_item( cw_unpack_context* context, int tabLevel)
             if(*tabString) NEW_LINE;
             printf("]");
             break;
-            
+
         case CWP_ITEM_MAP:
             printf("{");
             dim = context->item.as.map.size;
@@ -149,7 +149,7 @@ static void dump_next_item( cw_unpack_context* context, int tabLevel)
             if(*tabString) NEW_LINE;
             printf("}");
             break;
-            
+
         case CWP_ITEM_TIMESTAMP:
             printf("'");
             gmtime_r(&context->item.as.time.tv_sec,&tm);
@@ -163,7 +163,7 @@ static void dump_next_item( cw_unpack_context* context, int tabLevel)
             }
             printf("'");
             break;
-            
+
         default:
             if (CWP_ITEM_MIN_RESERVED_EXT <= context->item.type && context->item.type <= CWP_ITEM_MAX_USER_EXT)
             {
@@ -215,7 +215,7 @@ int main(int argc, const char * argv[])
 
     file_unpack_context fuc;
     cw_unpack_context *context = (cw_unpack_context*)&fuc;
-    
+
     init_file_unpack_context (&fuc, 4096, STDIN_FILENO);
     file_unpack_context_set_barrier (&fuc); /* keep whole file in memory buffer to simplify offset calculation */
 

--- a/goodies/numeric-extensions/numeric_extensions.c
+++ b/goodies/numeric-extensions/numeric_extensions.c
@@ -41,32 +41,32 @@ void cw_pack_ext_integer (cw_pack_context* pack_context, int8_t type, int64_t i)
 {
     if (pack_context->return_code)
         return;
-    
+
     uint8_t *p;
 
     if (i >= 0)
     {
         if (i < 128)
             cw_storeN(3,0xd4,8);
-        
+
         if (i < 32768)
             cw_storeN(4,0xd5,16);
-        
+
         if (i < 0x80000000LL)
             cw_storeN(6,0xd6,32);
-        
+
         cw_storeN(10,0xd7,64);
     }
-    
+
     if (i >= -128)
         cw_storeN(3,0xd4,8);
-    
+
     if (i >= -32768)
         cw_storeN(4,0xd5,16);
-    
+
     if (i >= (int64_t)0xffffffff80000000LL)
         cw_storeN(6,0xd6,32);
-    
+
     cw_storeN(10,0xd7,64);
 }
 
@@ -75,13 +75,13 @@ void cw_pack_ext_float (cw_pack_context* pack_context, int8_t type, float f)
 {
     if (pack_context->return_code)
         return;
-    
+
     uint8_t *p;
-    
+
     cw_pack_reserve_space(6);
     *p++ = (uint8_t)0xd6;
     *p++ = (uint8_t)type;
-    
+
     uint32_t tmp = *((uint32_t*)&f);
     cw_store32(tmp);
 }
@@ -91,13 +91,13 @@ void cw_pack_ext_double (cw_pack_context* pack_context, int8_t type, double d)
 {
     if (pack_context->return_code)
         return;
-    
+
     uint8_t *p;
-    
+
     cw_pack_reserve_space(10);
     *p++ = (uint8_t)0xd7;
     *p++ = (uint8_t)type;
-    
+
     uint64_t tmp = *((uint64_t*)&d);
     cw_store64(tmp);
 }
@@ -113,7 +113,7 @@ int64_t get_ext_integer (cw_unpack_context* unpack_context)
     uint16_t    tmpu16;
     uint32_t    tmpu32;
     uint64_t    tmpu64;
-    
+
     if (unpack_context->item.type > CWP_ITEM_MAX_USER_EXT)
     {
         unpack_context->return_code = CWP_RC_TYPE_ERROR;
@@ -163,7 +163,7 @@ float get_ext_float (cw_unpack_context* unpack_context)
         unpack_context->return_code = CWP_RC_VALUE_ERROR;
         return 0.0;
     }
-    
+
     cw_load32(unpack_context->item.as.ext.start);
     return *(float*)&tmpu32;
 }

--- a/goodies/numeric-extensions/numeric_extensions.h
+++ b/goodies/numeric-extensions/numeric_extensions.h
@@ -30,18 +30,18 @@
 #define NUMEXT_ERROR_NOT_EXT        CWP_RC_TYPE_ERROR;
 #define NUMEXT_ERROR_WRONG_LENGTH   CWP_RC_VALUE_ERROR;
 
-    
-    
-    
+
+
+
     void cw_pack_ext_integer (cw_pack_context* pack_context, int8_t type, int64_t i);
     void cw_pack_ext_float (cw_pack_context* pack_context, int8_t type, float f);
     void cw_pack_ext_double (cw_pack_context* pack_context, int8_t type, double d);
 
-    
+
     int64_t get_ext_integer (cw_unpack_context* unpack_context);
     float get_ext_float (cw_unpack_context* unpack_context);
     double get_ext_double (cw_unpack_context* unpack_context);
 
-    
+
 
 #endif /* numeric_extensions_h */

--- a/goodies/numeric-extensions/numeric_extensions_test.c
+++ b/goodies/numeric-extensions/numeric_extensions_test.c
@@ -59,7 +59,7 @@ static char char2hex (char c)
         return c - '0';
     if (c <= 'F')
         return c - 'A' + 10;
-    
+
     return c - 'a' + 10;
 }
 
@@ -70,7 +70,7 @@ static void check_pack_result(const char* expected_header, unsigned long data_le
     unsigned long header_length = strlen(expected_header) / 2;
     if (pack_ctx.current - outbuffer == (long)(header_length + data_length))
     {
-        
+
         if (header_length*2 == strlen(expected_header))
         {
             unsigned long i;
@@ -102,14 +102,14 @@ static void check_pack_result(const char* expected_header, unsigned long data_le
                     hex <<= 4;
                     hex += (uc - 'A' + 10);
                 }
-                
-                
+
+
                 if (*p++ != hex)
                 {
                     ERROR("Different header value");
                 }
             }
-            
+
             if (data_length > 0)
             {
                 ucp = TEST_area;
@@ -133,18 +133,18 @@ int main(int argc, const char * argv[])
 {
     printf("CWPack numeric extensions test started.\n");
     error_count = 0;
-    
+
     bool endian_switch_found = false;
 #ifdef COMPILE_FOR_BIG_ENDIAN
     printf("Compiled for big endian.\n\n");
     endian_switch_found = true;
 #endif
-    
+
 #ifdef COMPILE_FOR_LITTLE_ENDIAN
     printf("Compiled for little endian.\n\n");
     endian_switch_found = true;
 #endif
-    
+
     if (!endian_switch_found)
     {
         printf("Compiled for all endians.\n");
@@ -154,51 +154,51 @@ int main(int argc, const char * argv[])
             case 0x31323334UL:
                 printf("Running on big endian hardware.\n\n");
                 break;
-                
+
             case 0x34333231UL:
                 printf("Running on little endian hardware.\n\n");
                 break;
-                
+
             default:
                 printf("Running on neither little nor big endian hardware.\n\n");
                 break;
         }
     }
-    
-    
+
+
     //*******************   TEST numeric extensions  ****************************
-    
+
     cw_pack_context_init (&pack_ctx, outbuffer, 70000, 0);
     if (pack_ctx.return_code == CWP_RC_WRONG_BYTE_ORDER)
     {
         ERROR("***** Compiled for wrong byte order, test terminated *****\n\n");
         exit(1);
     }
-    
-        
-    
-    
+
+
+
+
 #define TESTP_EXT(call,type,value,header)           \
     pack_ctx.current = outbuffer;                   \
     cw_pack_ext_##call (&pack_ctx, type, value);    \
     if(pack_ctx.return_code)                        \
         ERROR("In pack");                           \
     check_pack_result(header, 0)
-    
+
     // TESTP ext
     TESTP_EXT(integer,15,1,"d40f01");
     TESTP_EXT(integer,15,128,"d50f0080");
     TESTP_EXT(integer,15,-32769,"d60fffff7fff");
-    
+
     float f1 = (float)3.14;
     TESTP_EXT(float,15,f1,"d60f4048f5c3");
     TESTP_EXT(double,15,f1,"d70f40091eb860000000");
-    
+
     int64_t integer_var;
     float float_var;
     double double_var;
     char inputbuf[30];
-    
+
 #define TESTUP_EXT(buffer,etype,call,value)                                                 \
 {                                                                                           \
     unsigned long ui;                                                                       \
@@ -217,30 +217,30 @@ int main(int argc, const char * argv[])
     if (call##_var != value)                                                                \
         ERROR("In unpack, value error");                                                    \
 }
-    
+
     TESTUP_EXT("d40f01",15,integer,1);
     TESTUP_EXT("d50f0080",15,integer,128);
     TESTUP_EXT("d60fffff7fff",15,integer,-32769);
     TESTUP_EXT("d60f4048f5c3",15,float,f1);
     TESTUP_EXT("d70f40091eb860000000",15,double,(double)f1);
     //*************************************************************
-    
+
     printf("CWPack numeric extensions test completed, ");
     switch (error_count)
     {
         case 0:
             printf("no errors detected\n");
             break;
-            
+
         case 1:
             printf("1 error detected\n");
             break;
-            
+
         default:
             printf("%d errors detected\n", error_count);
             break;
     }
-    
+
     return error_count;
 }
 

--- a/goodies/objC/README.md
+++ b/goodies/objC/README.md
@@ -1,7 +1,7 @@
 # CWPack / Goodies / ObjC
 
 
-ObjC contains a wrapper for objective-C in the form of a category to NSObject.  
+ObjC contains a wrapper for objective-C in the form of a category to NSObject.
 The category contains two methods:
 
 ```C

--- a/goodies/objC/cwpack_objc.h
+++ b/goodies/objC/cwpack_objc.h
@@ -1,18 +1,18 @@
 /*      CWPack/goodies - cwpack_objc.h   */
 /*
  The MIT License (MIT)
- 
+
  Copyright (c) 2017 Claes Wihlborg
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy of this
  software and associated documentation files (the "Software"), to deal in the Software
  without restriction, including without limitation the rights to use, copy, modify,
  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
  persons to whom the Software is furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all copies or
  substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
  BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/goodies/objC/cwpack_objc.m
+++ b/goodies/objC/cwpack_objc.m
@@ -1,18 +1,18 @@
 /*      CWPack/goodies - cwpack_objc.m   */
 /*
  The MIT License (MIT)
- 
+
  Copyright (c) 2017 Claes Wihlborg
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy of this
  software and associated documentation files (the "Software"), to deal in the Software
  without restriction, including without limitation the rights to use, copy, modify,
  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
  persons to whom the Software is furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all copies or
  substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
  BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -43,7 +43,7 @@ id cwObjectFromBuffer (cw_unpack_context* inbuf);
 + (instancetype) unpackFrom:(cw_unpack_context*) buff
 {
     id result = cwObjectFromBuffer(buff);
-    
+
     if (![[result class] isSubclassOfClass:self])
     {
         if ([[result class] isSubclassOfClass:[NSArray class]] && [self isSubclassOfClass:[NSSet class]])
@@ -205,33 +205,33 @@ id cwObjectFromBuffer (cw_unpack_context* inbuf)
     cw_unpack_next(inbuf);
     if (inbuf->return_code)
         return nil;
-    
+
     switch (inbuf->item.type)
     {
         case CWP_ITEM_NIL:
             return [NSNull null];
-            
+
         case CWP_ITEM_BOOLEAN:
             return [NSNumber numberWithBool:inbuf->item.as.boolean];
-            
+
         case CWP_ITEM_POSITIVE_INTEGER:
             return [NSNumber numberWithUnsignedLongLong:inbuf->item.as.u64];
-            
+
         case CWP_ITEM_NEGATIVE_INTEGER:
             return [NSNumber numberWithLongLong:inbuf->item.as.i64];
-            
+
         case CWP_ITEM_FLOAT:
             return [[NSNumber alloc] initWithFloat:inbuf->item.as.real];
-            
+
         case CWP_ITEM_DOUBLE:
             return [NSNumber numberWithDouble:inbuf->item.as.long_real];
-            
+
         case CWP_ITEM_STR:
             return [[[NSString alloc] initWithBytes:inbuf->item.as.str.start length:inbuf->item.as.str.length encoding:NSUTF8StringEncoding] autorelease];
-            
+
         case CWP_ITEM_BIN:
             return [NSData dataWithBytes:inbuf->item.as.bin.start length:inbuf->item.as.bin.length];
-            
+
         case CWP_ITEM_ARRAY:
         {
             int i, dim = inbuf->item.as.array.size;
@@ -244,7 +244,7 @@ id cwObjectFromBuffer (cw_unpack_context* inbuf)
             }
             return arr;
         }
-            
+
         case CWP_ITEM_MAP:
         {
             int i, dim = inbuf->item.as.map.size;
@@ -258,12 +258,12 @@ id cwObjectFromBuffer (cw_unpack_context* inbuf)
             }
             return dict;
         }
-            
+
         case CWP_ITEM_TIMESTAMP:
         {
             return [NSDate dateWithTimeIntervalSince1970:inbuf->item.as.time.tv_sec + inbuf->item.as.time.tv_nsec / 1000000000.0];
         }
-            
+
         default:
             return nil;
     }

--- a/goodies/utils/README.md
+++ b/goodies/utils/README.md
@@ -3,7 +3,7 @@
 
 Utils contains some convenience routines:
 
-### C string packing 
+### C string packing
 ```C
 void cw_pack_cstr (cw_pack_context* pack_context, const char* v);
 ```

--- a/goodies/utils/cwpack_utils.c
+++ b/goodies/utils/cwpack_utils.c
@@ -1,18 +1,18 @@
 /*      CWPack/goodies - cwpack_utils.c   */
 /*
  The MIT License (MIT)
- 
+
  Copyright (c) 2017 Claes Wihlborg
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy of this
  software and associated documentation files (the "Software"), to deal in the Software
  without restriction, including without limitation the rights to use, copy, modify,
  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
  persons to whom the Software is furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all copies or
  substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
  BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -70,7 +70,7 @@ float cw_unpack_next_float (cw_unpack_context* unpack_context)
 {
     cw_unpack_next (unpack_context);
     if (unpack_context->return_code)        return NaN;
-    
+
     switch (unpack_context->item.type) {
         case CWP_ITEM_POSITIVE_INTEGER:     return unpack_context->item.as.u64;
         case CWP_ITEM_NEGATIVE_INTEGER:     return unpack_context->item.as.i64;
@@ -85,7 +85,7 @@ double cw_unpack_next_double (cw_unpack_context* unpack_context)
 {
     cw_unpack_next (unpack_context);
     if (unpack_context->return_code)        return NaN;
-    
+
     switch (unpack_context->item.type) {
         case CWP_ITEM_POSITIVE_INTEGER:     return unpack_context->item.as.u64;
         case CWP_ITEM_NEGATIVE_INTEGER:     return unpack_context->item.as.i64;
@@ -101,10 +101,10 @@ bool cw_unpack_next_boolean (cw_unpack_context* unpack_context)
     cw_unpack_next (unpack_context);
     if (unpack_context->return_code)
         return false;
-    
+
     if (unpack_context->item.type == CWP_ITEM_BOOLEAN)
         return unpack_context->item.as.boolean;
-    
+
     unpack_context->return_code = CWP_RC_TYPE_ERROR;
     return false;
 }
@@ -115,7 +115,7 @@ int64_t cw_unpack_next_signed64 (cw_unpack_context* unpack_context)
     cw_unpack_next (unpack_context);
     if (unpack_context->return_code)
         return 0;
-    
+
     if (unpack_context->item.type == CWP_ITEM_POSITIVE_INTEGER)
     {
         if (unpack_context->item.as.u64 <= INT64_MAX)
@@ -126,10 +126,10 @@ int64_t cw_unpack_next_signed64 (cw_unpack_context* unpack_context)
             return 0;
         }
     }
-    
+
     if (unpack_context->item.type == CWP_ITEM_NEGATIVE_INTEGER)
         return unpack_context->item.as.i64;
-    
+
     unpack_context->return_code = CWP_RC_TYPE_ERROR;
     return 0;
 }
@@ -140,7 +140,7 @@ int32_t cw_unpack_next_signed32 (cw_unpack_context* unpack_context)
     cw_unpack_next (unpack_context);
     if (unpack_context->return_code)
         return 0;
-    
+
     if (unpack_context->item.type == CWP_ITEM_POSITIVE_INTEGER)
     {
         if (unpack_context->item.as.u64 <= INT32_MAX)
@@ -161,7 +161,7 @@ int32_t cw_unpack_next_signed32 (cw_unpack_context* unpack_context)
             return 0;
         }
     }
-    
+
     unpack_context->return_code = CWP_RC_TYPE_ERROR;
     return 0;
 }
@@ -172,7 +172,7 @@ int16_t cw_unpack_next_signed16 (cw_unpack_context* unpack_context)
     cw_unpack_next (unpack_context);
     if (unpack_context->return_code)
         return 0;
-    
+
     if (unpack_context->item.type == CWP_ITEM_POSITIVE_INTEGER)
     {
         if (unpack_context->item.as.u64 <= INT16_MAX)
@@ -193,7 +193,7 @@ int16_t cw_unpack_next_signed16 (cw_unpack_context* unpack_context)
             return 0;
         }
     }
-    
+
     unpack_context->return_code = CWP_RC_TYPE_ERROR;
     return 0;
 }
@@ -204,7 +204,7 @@ int8_t cw_unpack_next_signed8 (cw_unpack_context* unpack_context)
     cw_unpack_next (unpack_context);
     if (unpack_context->return_code)
         return 0;
-    
+
     if (unpack_context->item.type == CWP_ITEM_POSITIVE_INTEGER)
     {
         if (unpack_context->item.as.u64 <= INT8_MAX)
@@ -225,7 +225,7 @@ int8_t cw_unpack_next_signed8 (cw_unpack_context* unpack_context)
             return 0;
         }
     }
-    
+
     unpack_context->return_code = CWP_RC_TYPE_ERROR;
     return 0;
 }
@@ -237,12 +237,12 @@ uint64_t cw_unpack_next_unsigned64 (cw_unpack_context* unpack_context)
     cw_unpack_next (unpack_context);
     if (unpack_context->return_code)
         return 0;
-    
+
     if (unpack_context->item.type == CWP_ITEM_POSITIVE_INTEGER)
     {
         return unpack_context->item.as.u64;
     }
-    
+
     unpack_context->return_code = CWP_RC_TYPE_ERROR;
     return 0;
 }
@@ -253,7 +253,7 @@ uint32_t cw_unpack_next_unsigned32 (cw_unpack_context* unpack_context)
     cw_unpack_next (unpack_context);
     if (unpack_context->return_code)
         return 0;
-    
+
     if (unpack_context->item.type == CWP_ITEM_POSITIVE_INTEGER)
     {
         if (unpack_context->item.as.u64 <= UINT32_MAX)
@@ -264,7 +264,7 @@ uint32_t cw_unpack_next_unsigned32 (cw_unpack_context* unpack_context)
             return 0;
         }
     }
-    
+
     unpack_context->return_code = CWP_RC_TYPE_ERROR;
     return 0;
 }
@@ -275,7 +275,7 @@ uint16_t cw_unpack_next_unsigned16 (cw_unpack_context* unpack_context)
     cw_unpack_next (unpack_context);
     if (unpack_context->return_code)
         return 0;
-    
+
     if (unpack_context->item.type == CWP_ITEM_POSITIVE_INTEGER)
     {
         if (unpack_context->item.as.u64 <= UINT16_MAX)
@@ -286,7 +286,7 @@ uint16_t cw_unpack_next_unsigned16 (cw_unpack_context* unpack_context)
             return 0;
         }
     }
-    
+
     unpack_context->return_code = CWP_RC_TYPE_ERROR;
     return 0;
 }
@@ -297,7 +297,7 @@ uint8_t cw_unpack_next_unsigned8 (cw_unpack_context* unpack_context)
     cw_unpack_next (unpack_context);
     if (unpack_context->return_code)
         return 0;
-    
+
     if (unpack_context->item.type == CWP_ITEM_POSITIVE_INTEGER)
     {
         if (unpack_context->item.as.u64 <= UINT8_MAX)
@@ -308,7 +308,7 @@ uint8_t cw_unpack_next_unsigned8 (cw_unpack_context* unpack_context)
             return 0;
         }
     }
-    
+
     unpack_context->return_code = CWP_RC_TYPE_ERROR;
     return 0;
 }
@@ -318,7 +318,7 @@ double cw_unpack_next_time_interval (cw_unpack_context* unpack_context)
 {
     cw_unpack_next (unpack_context);
     if (unpack_context->return_code)        return NaN;
-    
+
     if (unpack_context->item.type == CWP_ITEM_TIMESTAMP)
     {
         return (double)unpack_context->item.as.time.tv_sec + (double)unpack_context->item.as.time.tv_nsec/1000000000;

--- a/goodies/utils/cwpack_utils.h
+++ b/goodies/utils/cwpack_utils.h
@@ -1,18 +1,18 @@
 /*      CWPack/goodies - cwpack_utils.h   */
 /*
  The MIT License (MIT)
- 
+
  Copyright (c) 2017 Claes Wihlborg
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy of this
  software and associated documentation files (the "Software"), to deal in the Software
  without restriction, including without limitation the rights to use, copy, modify,
  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
  persons to whom the Software is furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all copies or
  substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
  BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/README.md
+++ b/src/README.md
@@ -13,7 +13,7 @@ The src folder contains all basic functionallity to use CWPack.
 **cwpack.c** contains the code.
 
 ## Contexts
-Central to CWPack is the concept of contexts. There are two: `cw_pack_context` and `cw_unpack_context`. They contains all the necessary bookkeeping and a reference to the appropriate context is given in all routine calls. 
+Central to CWPack is the concept of contexts. There are two: `cw_pack_context` and `cw_unpack_context`. They contains all the necessary bookkeeping and a reference to the appropriate context is given in all routine calls.
 
 CWPack is working against memory buffers. Handlers, stored in the context, are called when a buffer is filled up (packing) or needs refill (unpack). The contexts in this folder handles static memory buffers, but more complex contexts that handles dynamic memory, files and sockets can be found in [goodies/basic-contexts](https://github.com/clwi/CWPack/tree/master/goodies/basic-contexts).
 
@@ -22,7 +22,7 @@ First you choose a context that suits your needs and initiates it. Then you can 
 
 CWpack is using a streaming model, containers (arrays, maps) are read/written in parts, first the item containing the size and then the contained items one by one. Exception to this is the `cw_skip_items` function which skips whole containers.
 
-You find some convenience routines for packing and an expect api for unpacking in [goodies/utils](https://github.com/clwi/CWPack/tree/master/goodies/utils).  
+You find some convenience routines for packing and an expect api for unpacking in [goodies/utils](https://github.com/clwi/CWPack/tree/master/goodies/utils).
 You find an Objective-C wrapper in [goodies/objC](https://github.com/clwi/CWPack/tree/master/goodies/objC).
 
 

--- a/src/cwpack.c
+++ b/src/cwpack.c
@@ -1,18 +1,18 @@
 /*      CWPack - cwpack.c   */
 /*
  The MIT License (MIT)
- 
+
  Copyright (c) 2017 Claes Wihlborg
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy of this
  software and associated documentation files (the "Software"), to deal in the Software
  without restriction, including without limitation the rights to use, copy, modify,
  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
  persons to whom the Software is furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all copies or
  substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
  BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -103,7 +103,7 @@ void cw_pack_unsigned(cw_pack_context* pack_context, uint64_t i)
 {
     if (pack_context->return_code)
         return;
-    
+
     if (i < 128)
         tryMove0(i);
 
@@ -125,27 +125,27 @@ void cw_pack_signed(cw_pack_context* pack_context, int64_t i)
 {
     if (pack_context->return_code)
         return;
-    
+
     if (i >127)
     {
         if (i < 256)
             tryMove1(0xcc, i);
-        
+
         if (i < 0x10000L)
             tryMove2(0xcd, i);
-        
+
         if (i < 0x100000000LL)
             tryMove4(0xce, i);
-        
+
         tryMove8(0xcf,i);
     }
-    
+
     if (i >= -32)
         tryMove0(i);
 
     if (i >= -128)
         tryMove1(0xd0, i);
-    
+
     if (i >= -32768)
         tryMove2(0xd1,i);
 
@@ -160,7 +160,7 @@ void cw_pack_float(cw_pack_context* pack_context, float f)
 {
     if (pack_context->return_code)
         return;
-    
+
     uint32_t tmp = *((uint32_t*)&f);
     tryMove4(0xca,tmp);
 }
@@ -170,7 +170,7 @@ void cw_pack_double(cw_pack_context* pack_context, double d)
 {
     if (pack_context->return_code)
         return;
-    
+
     uint64_t tmp = *((uint64_t*)&d);
     tryMove8(0xcb,tmp);
 }
@@ -189,7 +189,7 @@ void cw_pack_true (cw_pack_context* pack_context)
 {
     if (pack_context->return_code)
         return;
-    
+
     tryMove0(0xc3);
 }
 
@@ -198,7 +198,7 @@ void cw_pack_false (cw_pack_context* pack_context)
 {
     if (pack_context->return_code)
         return;
-    
+
     tryMove0(0xc2);
 }
 
@@ -207,7 +207,7 @@ void cw_pack_boolean(cw_pack_context* pack_context, bool b)
 {
     if (pack_context->return_code)
         return;
-    
+
     tryMove0(b? 0xc3: 0xc2);
 }
 
@@ -216,7 +216,7 @@ void cw_pack_array_size(cw_pack_context* pack_context, uint32_t n)
 {
     if (pack_context->return_code)
         return;
-    
+
     if (n < 16)
         tryMove0(0x90 | n);
 
@@ -231,7 +231,7 @@ void cw_pack_map_size(cw_pack_context* pack_context, uint32_t n)
 {
     if (pack_context->return_code)
         return;
-    
+
     if (n < 16)
         tryMove0(0x80 | n);
 
@@ -246,9 +246,9 @@ void cw_pack_str(cw_pack_context* pack_context, const char* v, uint32_t l)
 {
     if (pack_context->return_code)
         return;
-    
+
     uint8_t *p;
-    
+
     if (l < 32)             // Fixstr
     {
         cw_pack_reserve_space(l+1);
@@ -285,15 +285,15 @@ void cw_pack_bin(cw_pack_context* pack_context, const void* v, uint32_t l)
 {
     if (pack_context->return_code)
         return;
-    
+
     if (pack_context->be_compatible)
     {
         cw_pack_str( pack_context, v, l);
         return;
     }
-    
+
     uint8_t *p;
-    
+
     if (l < 256)            // Bin 8
     {
         cw_pack_reserve_space(l+2);
@@ -323,12 +323,12 @@ void cw_pack_ext (cw_pack_context* pack_context, int8_t type, const void* v, uin
 {
     if (pack_context->return_code)
         return;
-    
+
     if (pack_context->be_compatible)
         PACK_ERROR(CWP_RC_ILLEGAL_CALL);
-    
+
     uint8_t *p;
-    
+
     switch (l)
     {
         case 1:                                         // Fixext 1
@@ -471,7 +471,7 @@ void cw_unpack_next (cw_unpack_context* unpack_context)
     uint32_t    tmpu32;
     uint16_t    tmpu16;
     uint8_t*    p;
-    
+
 #define buffer_end_return_code  CWP_RC_END_OF_INPUT;
     cw_unpack_assert_space(1);
     uint8_t c = *p;
@@ -591,7 +591,7 @@ void cw_unpack_next (cw_unpack_context* unpack_context)
         default:
                     UNPACK_ERROR(CWP_RC_MALFORMED_INPUT)
     }
-    
+
     return;
 }
 
@@ -603,11 +603,11 @@ void cw_skip_items (cw_unpack_context* unpack_context, long item_count)
 {
     if (unpack_context->return_code)
         return;
-    
+
     uint32_t    tmpu32;
     uint16_t    tmpu16;
     uint8_t*    p;
-    
+
     while (item_count-- > 0)
     {
 #undef buffer_end_return_code
@@ -669,19 +669,19 @@ void cw_skip_items (cw_unpack_context* unpack_context, long item_count)
                 cw_unpack_assert_space(1);
                 tmpu32 = *p;
                 cw_skip_bytes(tmpu32);
-                
+
             case 0xda:                                          // str 16
             case 0xc5:                                          // bin 16
                 cw_unpack_assert_space(2);
                 cw_load16(p);
                 cw_skip_bytes(tmpu16);
-                
+
             case 0xdb:                                          // str 32
             case 0xc6:                                          // bin 32
                 cw_unpack_assert_space(4);
                 cw_load32(p);
                 cw_skip_bytes(tmpu32);
-                
+
             case 0x80: case 0x81: case 0x82: case 0x83: case 0x84: case 0x85: case 0x86: case 0x87:
             case 0x88: case 0x89: case 0x8a: case 0x8b: case 0x8c: case 0x8d: case 0x8e: case 0x8f:
                 item_count += 2*(c & 15);                       // FixMap
@@ -691,46 +691,46 @@ void cw_skip_items (cw_unpack_context* unpack_context, long item_count)
             case 0x98: case 0x99: case 0x9a: case 0x9b: case 0x9c: case 0x9d: case 0x9e: case 0x9f:
                 item_count += c & 15;                           // FixArray
                 break;
-                
+
             case 0xdc:                                          // array 16
                 cw_unpack_assert_space(2);
                 cw_load16(p);
                 item_count += tmpu16;
                 break;
-                
+
             case 0xde:                                          // map 16
                 cw_unpack_assert_space(2);
                 cw_load16(p);
                 item_count += 2*tmpu16;
                 break;
-                
+
             case 0xdd:                                          // array 32
                 cw_unpack_assert_space(4);
                 cw_load32(p);
                 item_count += tmpu32;
                 break;
-                
+
             case 0xdf:                                          // map 32
                 cw_unpack_assert_space(4);
                 cw_load32(p);
                 item_count += 2*tmpu32;
                 break;
-                
+
             case 0xc7:                                          // ext 8
                 cw_unpack_assert_space(1);
                 tmpu32 = *p;
                 cw_skip_bytes(tmpu32 +1);
-                
+
             case 0xc8:                                          // ext 16
                 cw_unpack_assert_space(2);
                 cw_load16(p);
                 cw_skip_bytes(tmpu16 +1);
-                
+
             case 0xc9:                                          // ext 32
                 cw_unpack_assert_space(4);
                 cw_load32(p);
                 cw_skip_bytes(tmpu32 +1);
-                
+
             default:                                            // illegal
                 UNPACK_ERROR(CWP_RC_MALFORMED_INPUT)
         }

--- a/src/cwpack.h
+++ b/src/cwpack.h
@@ -1,18 +1,18 @@
 /*      CWPack - cwpack.h   */
 /*
  The MIT License (MIT)
- 
+
  Copyright (c) 2017 Claes Wihlborg
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy of this
  software and associated documentation files (the "Software"), to deal in the Software
  without restriction, including without limitation the rights to use, copy, modify,
  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
  persons to whom the Software is furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all copies or
  substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
  BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/cwpack_config.h
+++ b/src/cwpack_config.h
@@ -1,18 +1,18 @@
 /*      CWPack - cwpack_config.h   */
 /*
  The MIT License (MIT)
- 
+
  Copyright (c) 2017 Claes Wihlborg
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy of this
  software and associated documentation files (the "Software"), to deal in the Software
  without restriction, including without limitation the rights to use, copy, modify,
  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
  persons to whom the Software is furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all copies or
  substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
  BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -58,7 +58,7 @@
 /*************************   B Y T E   O R D E R   ****************************/
 
 /*
- * The pack/unpack routines are written in three versions: for big endian, for 
+ * The pack/unpack routines are written in three versions: for big endian, for
  * little endian and insensitive to byte order. As you can get some speed gain
  * if the byte order is known, we try that when we can certainly detect it.
  * Define COMPILE_FOR_BIG_ENDIAN or COMPILE_FOR_LITTLE_ENDIAN if you know.

--- a/src/cwpack_internals.h
+++ b/src/cwpack_internals.h
@@ -1,18 +1,18 @@
 /*      CWPack - cwpack_defines.h   */
 /*
  The MIT License (MIT)
- 
+
  Copyright (c) 2017 Claes Wihlborg
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy of this
  software and associated documentation files (the "Software"), to deal in the Software
  without restriction, including without limitation the rights to use, copy, modify,
  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
  persons to whom the Software is furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all copies or
  substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
  BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/test/cwpack_module_test.c
+++ b/test/cwpack_module_test.c
@@ -1,18 +1,18 @@
 /*      CWPack/test cwpack_module_test.c   */
 /*
  The MIT License (MIT)
- 
+
  Copyright (c) 2017 Claes Wihlborg
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy of this
  software and associated documentation files (the "Software"), to deal in the Software
  without restriction, including without limitation the rights to use, copy, modify,
  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
  persons to whom the Software is furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all copies or
  substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
  BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -65,7 +65,7 @@ static char char2hex (char c)
         return c - '0';
     if (c <= 'F')
         return c - 'A' + 10;
-    
+
     return c - 'a' + 10;
 }
 
@@ -76,7 +76,7 @@ static void check_pack_result(const char* expected_header, unsigned long data_le
     unsigned long header_length = strlen(expected_header) / 2;
     if (pack_ctx.current - outbuffer == (long)(header_length + data_length))
     {
-        
+
         if (header_length*2 == strlen(expected_header))
         {
             unsigned long i;
@@ -108,14 +108,14 @@ static void check_pack_result(const char* expected_header, unsigned long data_le
                     hex <<= 4;
                     hex += (uc - 'A' + 10);
                 }
-                
-                
+
+
                 if (*p++ != hex)
                 {
                     ERROR("Different header value");
                 }
             }
-            
+
             if (data_length > 0)
             {
                 ucp = TEST_area;
@@ -150,68 +150,68 @@ int main(int argc, const char * argv[])
 {
     printf("CWPack module test started.\n");
     error_count = 0;
-    
+
     bool endian_switch_found = false;
 #ifdef COMPILE_FOR_BIG_ENDIAN
     printf("Compiled for big endian.\n");
     endian_switch_found = true;
 #endif
-    
+
 #ifdef COMPILE_FOR_LITTLE_ENDIAN
     printf("Compiled for little endian.\n");
     endian_switch_found = true;
 #endif
-    
+
     if (!endian_switch_found)
         printf("Compiled for all endians.\n");
-    
+
     const char *endianness = "1234";
     switch (*(uint32_t*)endianness)
     {
         case 0x31323334UL:
             printf("Running on big endian hardware.\n\n");
             break;
-            
+
         case 0x34333231UL:
             printf("Running on little endian hardware.\n\n");
             break;
-            
+
         default:
             printf("Running on neither little nor big endian hardware.\n\n");
             break;
     }
-    
-   
+
+
     //*******************   TEST cwpack pack  ****************************
-    
-    
+
+
 #define TESTP(call,data,result)                     \
     pack_ctx.current = outbuffer;                    \
     cw_pack_##call (&pack_ctx, data);                \
     if(pack_ctx.return_code)                         \
         ERROR("In pack");                           \
     check_pack_result(result,0)
-    
-    
-    
+
+
+
     cw_pack_context_init (&pack_ctx, outbuffer, 70000, 0);
     if (pack_ctx.return_code == CWP_RC_WRONG_BYTE_ORDER)
     {
         ERROR("***** Compiled for wrong byte order, test terminated *****\n\n");
         exit(1);
     }
-    
+
     unsigned int ui;
     for (ui=0; ui<70000; ui++)
     {
         TEST_area[ui] = ui & 0x7fUL;
     }
-    
-    
+
+
     // TESTP NIL
     cw_pack_nil(&pack_ctx);
     check_pack_result("c0",0);
-    
+
     // TESTP boolean
     pack_ctx.current = outbuffer;
     cw_pack_true(&pack_ctx);
@@ -221,7 +221,7 @@ int main(int argc, const char * argv[])
     check_pack_result("c2",0);
     TESTP(boolean,0,"c2");
     TESTP(boolean,1,"c3");
-    
+
     // TESTP unsigned int
     TESTP(unsigned,0,"00");
     TESTP(unsigned,127,"7f");
@@ -234,7 +234,7 @@ int main(int argc, const char * argv[])
     TESTP(unsigned,0xffffffffUL,"ceffffffff");
     TESTP(unsigned,0x100000000ULL,"cf0000000100000000");
     TESTP(unsigned,0xffffffffffffffffULL,"cfffffffffffffffff");
-    
+
     // TESTP signed int
     TESTP(signed,-1,"ff");
     TESTP(signed,-32,"e0");
@@ -243,7 +243,7 @@ int main(int argc, const char * argv[])
     TESTP(signed,-129,"d1ff7f");
     TESTP(signed,-32768,"d18000");
     TESTP(signed,-32769,"d2ffff7fff");
-    
+
     // TESTP real
     float f1 = (float)3.14;
     TESTP(float,0.0,"ca00000000");
@@ -257,29 +257,29 @@ int main(int argc, const char * argv[])
     TESTP(double_opt,f1,"ca4048f5c3");
     TESTP(double_opt,3.14,"cb40091eb851eb851f");
     TESTP(double_opt,-32,"e0");
-    
+
     // TESTP array
     TESTP(array_size,0,"90");
     TESTP(array_size,15,"9f");
     TESTP(array_size,16,"dc0010");
     TESTP(array_size,65535,"dcffff");
     TESTP(array_size,65536,"dd00010000");
-    
+
     // TESTP map
     TESTP(map_size,0,"80");
     TESTP(map_size,15,"8f");
     TESTP(map_size,16,"de0010");
     TESTP(map_size,65535,"deffff");
     TESTP(map_size,65536,"df00010000");
-    
-    
+
+
 #define TESTP_AREA(call,len,header)                     \
     pack_ctx.current = outbuffer;                        \
     cw_pack_##call (&pack_ctx, TEST_area, len);          \
     if(pack_ctx.return_code)                             \
         ERROR("In pack");                               \
     check_pack_result(header, len)
-    
+
     // TESTP str
     TESTP_AREA(str,0,"a0");
     TESTP_AREA(str,31,"bf");
@@ -288,21 +288,21 @@ int main(int argc, const char * argv[])
     TESTP_AREA(str,256,"da0100");
     TESTP_AREA(str,65535,"daffff");
     TESTP_AREA(str,65536,"db00010000");
-    
+
     // TESTP bin
     TESTP_AREA(bin,0,"c400");
     TESTP_AREA(bin,255,"c4ff");
     TESTP_AREA(bin,256,"c50100");
     TESTP_AREA(bin,65535,"c5ffff");
     TESTP_AREA(bin,65536,"c600010000");
-    
+
 #define TESTP_EXT(call,type,len,header)                 \
     pack_ctx.current = outbuffer;                        \
     cw_pack_##call (&pack_ctx, type, TEST_area, len);    \
     if(pack_ctx.return_code)                             \
         ERROR("In pack");                               \
     check_pack_result(header, len)
-    
+
     // TESTP ext
     TESTP_EXT(ext,15,1,"d40f");
     TESTP_EXT(ext,16,2,"d510");
@@ -314,7 +314,7 @@ int main(int argc, const char * argv[])
     TESTP_EXT(ext,21,256,"c8010015");
     TESTP_EXT(ext,21,65535,"c8ffff15");
     TESTP_EXT(ext,21,65536,"c90001000015");
-    
+
     pack_ctx.current = outbuffer;
     cw_pack_time(&pack_ctx, 1, 0);
     check_pack_result("d6ff00000001", 0);
@@ -326,12 +326,12 @@ int main(int argc, const char * argv[])
     check_pack_result("c70cff1dcd6500ffffffffffffffff", 0);
 
     TESTP(time_interval,-0.5,"c70cff1dcd6500ffffffffffffffff");
-    
+
     //*******************   TEST cwpack unpack   **********************
-    
+
     char inputbuf[30];
-    
-    
+
+
 #define TESTUP(buffer,etype)                                                            \
 {                                                                                       \
     unsigned long len = strlen(buffer)/2;                                               \
@@ -342,21 +342,21 @@ int main(int argc, const char * argv[])
     if (unpack_ctx.item.type != CWP_ITEM_##etype)                                       \
         ERROR("In unpack, type error");                                                 \
 }
-    
+
 #define TESTUP_VAL(buffer,etype,var,val)                    \
     TESTUP(buffer,etype);                                   \
     if (unpack_ctx.item.as.var != val)                      \
         ERROR("In unpack, value error");
 
     unsigned long blob_length = 0;
-    
+
     // TESTUP NIL
     TESTUP("c0",NIL);
-    
+
     // TESTUP boolean
     TESTUP_VAL("c2",BOOLEAN,boolean,false);
     TESTUP_VAL("c3",BOOLEAN,boolean,true);
-    
+
     // TESTUP unsigned int
     TESTUP_VAL("00",POSITIVE_INTEGER,u64,0)
     TESTUP_VAL("7f",POSITIVE_INTEGER,u64,127)
@@ -368,7 +368,7 @@ int main(int argc, const char * argv[])
     TESTUP_VAL("ceffffffff",POSITIVE_INTEGER,u64,0xffffffffUL)
     TESTUP_VAL("cf0000000100000000",POSITIVE_INTEGER,u64,0x100000000ULL)
     TESTUP_VAL("cfffffffffffffffff",POSITIVE_INTEGER,u64,0xffffffffffffffffULL)
-    
+
     // TESTUP signed int
     TESTUP_VAL("ff",NEGATIVE_INTEGER,i64,-1)
     TESTUP_VAL("e0",NEGATIVE_INTEGER,i64,-32)
@@ -378,7 +378,7 @@ int main(int argc, const char * argv[])
     TESTUP_VAL("d18000",NEGATIVE_INTEGER,i64,-32768)
     TESTUP_VAL("d2ffff7fff",NEGATIVE_INTEGER,i64,-32769)
     TESTUP_VAL("d3ffffffff7fffffff",NEGATIVE_INTEGER,i64,-2147483649)
-    
+
     // TESTUP real
     //    float f1 = 3.14;
     TESTUP_VAL("ca00000000",FLOAT,real,0.0)
@@ -386,21 +386,21 @@ int main(int argc, const char * argv[])
     TESTUP_VAL("cb0000000000000000",DOUBLE,long_real,0.0)
     TESTUP_VAL("cb40091eb860000000",DOUBLE,long_real,f1)
     TESTUP_VAL("cb40091eb851eb851f",DOUBLE,long_real,3.14)
-    
+
     // TESTUP array
     TESTUP_VAL("90",ARRAY,array.size,0)
     TESTUP_VAL("9f",ARRAY,array.size,15)
     TESTUP_VAL("dc0010",ARRAY,array.size,16)
     TESTUP_VAL("dcffff",ARRAY,array.size,65535)
     TESTUP_VAL("dd00010000",ARRAY,array.size,65536)
-    
+
     // TESTUP map
     TESTUP_VAL("80",MAP,map.size,0)
     TESTUP_VAL("8f",MAP,map.size,15)
     TESTUP_VAL("de0010",MAP,map.size,16)
     TESTUP_VAL("deffff",MAP,map.size,65535)
     TESTUP_VAL("df00010000",MAP,map.size,65536)
-    
+
     // TESTUP timeStamp
     TESTUP_VAL("d6ff00000001",TIMESTAMP,time.tv_sec,1);
     TESTUP_VAL("d6ff00000001",TIMESTAMP,time.tv_nsec,0);
@@ -421,14 +421,14 @@ int main(int argc, const char * argv[])
     TESTUP_AREA("da0100",STR,str,256);
     TESTUP_AREA("daffff",STR,str,65535);
     TESTUP_AREA("db00010000",STR,str,65536);
-    
+
     // TESTUP bin
     TESTUP_AREA("c400",BIN,bin,0);
     TESTUP_AREA("c4ff",BIN,bin,255);
     TESTUP_AREA("c50100",BIN,bin,256);
     TESTUP_AREA("c5ffff",BIN,bin,65535);
     TESTUP_AREA("c600010000",BIN,bin,65536);
-    
+
     // TESTUP ext
 #define CWP_ITEM_15 15
 #define CWP_ITEM_16 16
@@ -437,7 +437,7 @@ int main(int argc, const char * argv[])
 #define CWP_ITEM_19 19
 #define CWP_ITEM_20 20
 #define CWP_ITEM_21 21
-    
+
     TESTUP_AREA("d40f",15,ext,1);
     TESTUP_AREA("d510",16,ext,2);
     TESTUP_AREA("c70311",17,ext,3);
@@ -448,11 +448,11 @@ int main(int argc, const char * argv[])
     TESTUP_AREA("c8010015",21,ext,256);
     TESTUP_AREA("c8ffff15",21,ext,65535);
     TESTUP_AREA("c90001000015",21,ext,65536);
-    
 
-    
+
+
     //*******************   TEST skip   ***************************
-    
+
     cw_pack_context_init (&pack_ctx, outbuffer, 100, 0);
     cw_pack_array_size(&pack_ctx,2);
     cw_pack_str(&pack_ctx,"Test of skip",12); //array component
@@ -465,13 +465,13 @@ int main(int argc, const char * argv[])
     else
     {
         cw_unpack_context_init (&unpack_ctx, pack_ctx.start, (unsigned long)(pack_ctx.current-pack_ctx.start), 0);
-        
+
         cw_skip_items (&unpack_ctx, 1); /* skip whole array */
         check_unpack (0x952, CWP_RC_OK);
         check_unpack (0, CWP_RC_END_OF_INPUT);
     }
-    
-    
+
+
     //*************************************************************
 
     printf("CWPack module test completed, ");
@@ -480,15 +480,15 @@ int main(int argc, const char * argv[])
         case 0:
             printf("no errors detected\n");
             break;
-            
+
         case 1:
             printf("1 error detected\n");
             break;
-            
+
         default:
             printf("%d errors detected\n", error_count);
             break;
     }
-    
+
     return error_count;
 }

--- a/test/cwpack_performance_test.c
+++ b/test/cwpack_performance_test.c
@@ -99,64 +99,64 @@ static size_t b_writer(cmp_ctx_t *ctx, const void *data, size_t count)
 static void pack_test(void)
 {
     /***************  Test of pack  *****************/
-    
+
     cw_pack_context pc;
     cmp_ctx_t cc;
     mpack_writer_t mw;
-    
+
     int ii, itemSize;
     for (ii=0; ii<BUF_Length; ii++) buffer[ii] = 0; /*Load pages in memory*/
     uint8_t item[40];
-    
-    
+
+
     BEFORE_PTEST(cw_pack_nil(&pc));
     PTEST("CMP",cmp_write_nil(&cc));
     PTEST("MPack", mpack_write_nil(&mw));
     PTEST("CWPack", cw_pack_nil(&pc));
     AFTER_PTEST;
-    
+
     BEFORE_PTEST(cw_pack_signed(&pc, -1));
     PTEST("CMP",cmp_write_integer(&cc, -1));
     PTEST("MPack", mpack_write_i64(&mw, -1));
     PTEST("CWPack", cw_pack_signed(&pc, -1));
     AFTER_PTEST;
-    
+
     BEFORE_PTEST(cw_pack_signed(&pc, 200));
     PTEST("CMP",cmp_write_integer(&cc, 200));
     PTEST("MPack", mpack_write_i64(&mw, 200));
     PTEST("CWPack", cw_pack_signed(&pc, 200));
     AFTER_PTEST;
-    
+
     BEFORE_PTEST(cw_pack_signed(&pc, 10000));
     PTEST("CMP",cmp_write_integer(&cc, 10000));
     PTEST("MPack", mpack_write_i64(&mw, 10000));
     PTEST("CWPack", cw_pack_signed(&pc, 10000));
     AFTER_PTEST;
-    
+
     BEFORE_PTEST(cw_pack_signed(&pc, 100000));
     PTEST("CMP",cmp_write_integer(&cc, 100000));
     PTEST("MPack", mpack_write_i64(&mw, 100000));
     PTEST("CWPack", cw_pack_signed(&pc, 100000));
     AFTER_PTEST;
-    
+
     BEFORE_PTEST(cw_pack_float(&pc, (float)3.14));
     PTEST("CMP",cmp_write_float(&cc, (float)3.14));
     PTEST("MPack", mpack_write_float(&mw, (float)3.14));
     PTEST("CWPack", cw_pack_float(&pc, (float)3.14));
     AFTER_PTEST;
-    
+
     BEFORE_PTEST(cw_pack_double(&pc, 3.14));
     PTEST("CMP",cmp_write_decimal(&cc, 3.14));
     PTEST("MPack", mpack_write_double(&mw, 3.14));
     PTEST("CWPack", cw_pack_double(&pc, 3.14));
     AFTER_PTEST;
-    
+
     BEFORE_PTEST(cw_pack_str(&pc, "Claes",5));
     PTEST("CMP",cmp_write_str(&cc, "Claes",5));
     PTEST("MPack", mpack_write_str(&mw, "Claes",5));
     PTEST("CWPack", cw_pack_str(&pc, "Claes",5));
     AFTER_PTEST;
-    
+
     BEFORE_PTEST(cw_pack_str(&pc, "Longer string than the other one.",33));
     PTEST("CMP",cmp_write_str(&cc, "Longer string than the other one.",33));
     PTEST("MPack", mpack_write_str(&mw, "Longer string than the other one.",33));
@@ -204,7 +204,7 @@ static bool b_reader(struct cmp_ctx_s *ctx, void *data, size_t limit)
 {
     if (((char*)ctx->buf + limit) > (buffer + BUF_Length))
         return false;
-    
+
     memcpy (data,ctx->buf,limit);
     ctx->buf = (uint8_t*)ctx->buf + limit;
     return true;
@@ -213,43 +213,43 @@ static bool b_reader(struct cmp_ctx_s *ctx, void *data, size_t limit)
 static void unpack_test(void)
 {
     /***************  Test of unpack  *****************/
-    
+
     cw_pack_context pc;
     cw_unpack_context uc;
     mpack_reader_t mr;
     cmp_ctx_t cc;
     cmp_object_t cobj;
-    
+
     BEFORE_UTEST(cw_pack_nil(&pc));
     UTEST("CMP", cmp_read_object(&cc, &cobj));
     UTEST("MPack", mpack_read_tag(&mr));
     UTEST("CWPack", cw_unpack_next(&uc));
     AFTER_UTEST;
-    
+
     BEFORE_UTEST(cw_pack_signed(&pc, -1));
     UTEST("CMP", cmp_read_object(&cc, &cobj));
     UTEST("MPack", mpack_read_tag(&mr));
     UTEST("CWPack", cw_unpack_next(&uc));
     AFTER_UTEST;
-    
+
     BEFORE_UTEST(cw_pack_signed(&pc, 100000));
     UTEST("CMP", cmp_read_object(&cc, &cobj));
     UTEST("MPack", mpack_read_tag(&mr));
     UTEST("CWPack", cw_unpack_next(&uc));
     AFTER_UTEST;
-    
+
     BEFORE_UTEST(cw_pack_float(&pc, (float)3.14));
     UTEST("CMP", cmp_read_object(&cc, &cobj));
     UTEST("MPack", mpack_read_tag(&mr));
     UTEST("CWPack", cw_unpack_next(&uc));
     AFTER_UTEST;
-    
+
     BEFORE_UTEST(cw_pack_double(&pc, 3.14));
     UTEST("CMP", cmp_read_object(&cc, &cobj));
     UTEST("MPack", mpack_read_tag(&mr));
     UTEST("CWPack", cw_unpack_next(&uc));
     AFTER_UTEST;
-    
+
     BEFORE_UTEST(cw_pack_str(&pc, "Claes",5));
     UTEST("CMP", cmp_read_object(&cc, &cobj));
     UTEST("MPack", mpack_skip_bytes(&mr,mpack_expect_str(&mr));mpack_done_str(&mr));


### PR DESCRIPTION
Don't be scared. This pull request changes a lot of files but no code has been changed. All changes are purely cosmetic. They remove trailing whitespace, i.e. mainly spaces at the end of a line.

It's maybe not that important but there is a discussion about trailing whitespace and why to avoid it on [stackexchange](https://softwareengineering.stackexchange.com/questions/121555/why-is-trailing-whitespace-a-big-deal).