### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/cwpack.c
+++ b/src/cwpack.c
@@ -592,7 +592,6 @@ void cw_unpack_next (cw_unpack_context* unpack_context)
                     UNPACK_ERROR(CWP_RC_MALFORMED_INPUT)
     }
     
-    return;
 }
 
 #define cw_skip_bytes(n)                                \

--- a/src/cwpack.c
+++ b/src/cwpack.c
@@ -519,7 +519,7 @@ void cw_unpack_next (cw_unpack_context* unpack_context)
                     cw_unpack_assert_blob(bin);
         case 0xc7:  getDDItem1(CWP_ITEM_EXT, ext.length, uint8_t);              // ext 8
                     cw_unpack_assert_space(1);
-                    unpack_context->item.type = *(int8_t*)p;
+                    unpack_context->item.type = (cwpack_item_types)*(int8_t*)p;
                     if (unpack_context->item.type == CWP_ITEM_TIMESTAMP)
                     {
                         if (unpack_context->item.as.ext.length == 12)
@@ -537,11 +537,11 @@ void cw_unpack_next (cw_unpack_context* unpack_context)
                     cw_unpack_assert_blob(ext);
         case 0xc8:  getDDItem2(CWP_ITEM_EXT, ext.length, uint16_t);             // ext 16
                     cw_unpack_assert_space(1);
-                    unpack_context->item.type = *(int8_t*)p;
+                    unpack_context->item.type = (cwpack_item_types)*(int8_t*)p;
                     cw_unpack_assert_blob(ext);
         case 0xc9:  getDDItem4(CWP_ITEM_EXT, ext.length, uint32_t);             // ext 32
                     cw_unpack_assert_space(1);
-                    unpack_context->item.type = *(int8_t*)p;
+                    unpack_context->item.type = (cwpack_item_types)*(int8_t*)p;
                     cw_unpack_assert_blob(ext);
         case 0xca:  unpack_context->item.type = CWP_ITEM_FLOAT;                 // float
                     cw_unpack_assert_space(4);

--- a/src/cwpack.h
+++ b/src/cwpack.h
@@ -116,7 +116,7 @@ typedef enum
     CWP_ITEM_ARRAY                  = 308,
     CWP_ITEM_MAP                    = 309,
     CWP_ITEM_EXT                    = 310,
-    CWP_NOT_AN_ITEM                 = 999,
+    CWP_NOT_AN_ITEM                 = 999
 } cwpack_item_types;
 
 

--- a/src/cwpack_internals.h
+++ b/src/cwpack_internals.h
@@ -337,8 +337,8 @@
 
 #define getDDItemFix(len)                                                   \
     cw_unpack_assert_space(len+1);                                          \
-    unpack_context->item.type = *(int8_t*)p++;                              \
-    if (unpack_context->item.type == CWP_ITEM_TIMESTAMP)                     \
+    unpack_context->item.type = (cwpack_item_types)*(int8_t*)p++;           \
+    if (unpack_context->item.type == CWP_ITEM_TIMESTAMP)                    \
     {                                                                       \
         if (len == 4)                                                       \
         {                                                                   \

--- a/src/cwpack_internals.h
+++ b/src/cwpack_internals.h
@@ -347,14 +347,17 @@
             unpack_context->item.as.time.tv_nsec = 0;                       \
             return;                                                         \
         }                                                                   \
-        if (len == 8)                                                       \
+        else if (len == 8)                                                  \
         {                                                                   \
             cw_load64(p,tmpu64);                                            \
             unpack_context->item.as.time.tv_sec = tmpu64 & 0x00000003ffffffffL; \
             unpack_context->item.as.time.tv_nsec = tmpu64 >> 34;            \
             return;                                                         \
         }                                                                   \
-        UNPACK_ERROR(CWP_RC_WRONG_TIMESTAMP_LENGTH)                         \
+        else                                                                \
+        {                                                                   \
+            UNPACK_ERROR(CWP_RC_WRONG_TIMESTAMP_LENGTH)                     \
+        }                                                                   \
     }                                                                       \
     unpack_context->item.as.ext.length = len;                               \
     unpack_context->item.as.ext.start = p;                                  \


### PR DESCRIPTION
The commits attached to this pull request only fix compiler warnings.

Two of them (02910d9, 76ba28b) are adopted from pull request [Fix (possibly) undefined bit shifts](https://github.com/clwi/CWPack/pull/8), without other changes mixed:

> The other changes mostly fix warnings about unreachable statements, or assignments between enums and plain ints.
